### PR TITLE
custom_fileのtraitを変更

### DIFF
--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -11,14 +11,6 @@ pub trait File: Sized + Drop {
 
 pub trait FileFactory: Sized {
     fn new(path: PathBuf) -> Result<Self>;
-    fn get_file<FileType: File>(
-        &self,
-        uuid: Uuid,
-        args: FileType::InitArgs,
-    ) -> Result<FileType>;
-    fn get_hardlink_of<FileType: File>(
-        &self,
-        uuid: Uuid,
-        original: FileType,
-    ) -> Result<FileType>;
+    fn get_file<FileType: File>(&self, uuid: Uuid, args: FileType::InitArgs) -> Result<FileType>;
+    fn get_hardlink_of<FileType: File>(&self, uuid: Uuid, original: FileType) -> Result<FileType>;
 }

--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -6,18 +6,19 @@ use uuid::Uuid;
 pub trait File: Sized + Drop {
     type InitArgs;
     fn new(path: PathBuf, args: Self::InitArgs) -> Result<Self>;
-    fn get_path(&self) -> PathBuf;
+    fn hard_link(&self, path: PathBuf) -> Result<Self>;
 }
-
-pub trait FileEntity: File {}
-
-pub trait FileLink: File {}
 
 pub trait FileFactory: Sized {
     fn new(path: PathBuf) -> Result<Self>;
-    fn get_file_entity<FileType: File>(
+    fn get_file<FileType: File>(
         &self,
         uuid: Uuid,
         args: FileType::InitArgs,
+    ) -> Result<FileType>;
+    fn get_hardlink_of<FileType: File>(
+        &self,
+        uuid: Uuid,
+        original: FileType,
     ) -> Result<FileType>;
 }

--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 pub trait File: Sized + Drop {
     type InitArgs;
     fn new(path: PathBuf, args: Self::InitArgs) -> Result<Self>;
-    fn hard_link(&self, path: PathBuf) -> Result<Self>;
+    fn get_hardlink_to(&self, path: PathBuf) -> Result<Self>;
 }
 
 pub trait FileFactory: Sized {


### PR DESCRIPTION
## 関連Issue

- close #30

## 概要

k8sのsubPathを使えば、同一のshared volume内にexec containerから可視なファイルと不可視なファイルの両方をおいておくことができる。

## 変更内容

- FileEntity, FileLinkを削除
- File::get_pathを削除
- File::hardlinkを追加
- FileFactory::get_hardlink_toを追加

## 補足