### PR TITLE
Issue #34: Use `create` instead of `get`

### DIFF
--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -6,11 +6,11 @@ use uuid::Uuid;
 pub trait File: Sized + Drop {
     type InitArgs;
     fn new(path: PathBuf, args: Self::InitArgs) -> Result<Self>;
-    fn get_hardlink_to(&self, path: PathBuf) -> Result<Self>;
+    fn create_hardlink_to(&self, path: PathBuf) -> Result<Self>;
 }
 
 pub trait FileFactory: Sized {
     fn new(path: PathBuf) -> Result<Self>;
-    fn get_file<FileType: File>(&self, uuid: Uuid, args: FileType::InitArgs) -> Result<FileType>;
-    fn get_hardlink_of<FileType: File>(&self, uuid: Uuid, original: FileType) -> Result<FileType>;
+    fn create_file<FileType: File>(&self, uuid: Uuid, args: FileType::InitArgs) -> Result<FileType>;
+    fn create_hardlink_of<FileType: File>(&self, uuid: Uuid, original: FileType) -> Result<FileType>;
 }

--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -11,6 +11,11 @@ pub trait File: Sized + Drop {
 
 pub trait FileFactory: Sized {
     fn new(path: PathBuf) -> Result<Self>;
-    fn create_file<FileType: File>(&self, uuid: Uuid, args: FileType::InitArgs) -> Result<FileType>;
-    fn create_hardlink_of<FileType: File>(&self, uuid: Uuid, original: FileType) -> Result<FileType>;
+    fn create_file<FileType: File>(&self, uuid: Uuid, args: FileType::InitArgs)
+        -> Result<FileType>;
+    fn create_hardlink_of<FileType: File>(
+        &self,
+        uuid: Uuid,
+        original: FileType,
+    ) -> Result<FileType>;
 }


### PR DESCRIPTION
## 関連Issue
- close #34

## 概要
`get_file` や `get_hardlink_of` でファイルやハードリンクが作成されているが，これは `get` より `create` のほうが適切

## 変更内容
`get` を `create` に書き換えた

## 補足