### PR TITLE
add `&` to custom file trait

### DIFF
--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -16,6 +16,6 @@ pub trait FileFactory: Sized {
     fn create_hardlink_of<FileType: File>(
         &self,
         uuid: Uuid,
-        original: FileType,
+        original: &FileType,
     ) -> Result<FileType>;
 }


### PR DESCRIPTION
## 関連Issue

- close #49 

## 概要

`create_hardlink_of` の引数 `original: FileType` は `original: &FileType` であるべき

## 変更内容

`&` を付け加えた

## チェックリスト
- [x] テストが通っている
- [x] 下記のいずれかを満たしている
    - - [ ] 変更点についてテストを追加/修正した
    - - [ ] テストを追加するissueを立てた
    - - [x] テストが不要な変更である
- [x] レビュワーを指定した
- [x] タグをつけた

## 補足