### PR TITLE
Feature/#7 add custom file

### DIFF
--- a/judge-control-app/src/custom_file.rs
+++ b/judge-control-app/src/custom_file.rs
@@ -1,1 +1,5 @@
 pub mod traits;
+
+pub mod directory;
+pub mod file_factory;
+pub mod text_file;

--- a/judge-control-app/src/custom_file/directory.rs
+++ b/judge-control-app/src/custom_file/directory.rs
@@ -5,7 +5,7 @@ use std::{
 
 use super::traits::{File, FileEntity, FileLink};
 
-struct DirectoryEntity {
+pub struct DirectoryEntity {
     path: PathBuf,
 }
 
@@ -26,7 +26,7 @@ impl Drop for DirectoryEntity {
     }
 }
 
-struct DirectoryLink {
+pub struct DirectoryLink {
     path: PathBuf,
     entity: Arc<RwLock<DirectoryEntity>>,
 }

--- a/judge-control-app/src/custom_file/directory.rs
+++ b/judge-control-app/src/custom_file/directory.rs
@@ -1,28 +1,56 @@
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    sync::{Arc, RwLock},
+};
 
-use anyhow::{anyhow, Result};
+use super::traits::{File, FileEntity, FileLink};
 
-use super::traits::File;
-
-pub struct Directory {
+struct DirectoryEntity {
     path: PathBuf,
 }
 
-impl File for Directory {
+impl FileEntity for DirectoryEntity {}
+
+impl File for DirectoryEntity {
     type InitArgs = ();
-    fn new(path: PathBuf, _args: Self::InitArgs) -> Result<Self> {
+    fn new(path: PathBuf, _args: Self::InitArgs) -> anyhow::Result<Self> {
         std::fs::create_dir_all(&path)?;
-        Ok(Directory { path })
-    }
-    fn create_hardlink_to(&self, _path: PathBuf) -> Result<Self> {
-        Err(anyhow!("hard link not allowed for directory"))
+        Ok(Self { path })
     }
 }
 
-impl Drop for Directory {
+impl Drop for DirectoryEntity {
     fn drop(&mut self) {
-        if let Err(e) = std::fs::remove_dir_all(&self.path) {
-            eprintln!("{:?}", e);
-        }
+        let _ = std::fs::remove_dir_all(&self.path);
+        unimplemented!("error handling for file deletion failure");
+    }
+}
+
+struct DirectoryLink {
+    path: PathBuf,
+    entity: Arc<RwLock<DirectoryEntity>>,
+}
+
+impl FileLink for DirectoryLink {
+    fn create_symlink_to(&self, path: PathBuf) -> anyhow::Result<Self> {
+        Self::new(path, self.entity.clone())
+    }
+}
+
+impl File for DirectoryLink {
+    type InitArgs = Arc<RwLock<DirectoryEntity>>;
+    fn new(path: PathBuf, args: Self::InitArgs) -> anyhow::Result<Self> {
+        std::os::unix::fs::symlink(&args.read().unwrap().path, &path)?;
+        Ok(Self {
+            path,
+            entity: args.clone(),
+        })
+    }
+}
+
+impl Drop for DirectoryLink {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+        unimplemented!("error handling for file deletion failure");
     }
 }

--- a/judge-control-app/src/custom_file/directory.rs
+++ b/judge-control-app/src/custom_file/directory.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Result};
+
+use super::traits::File;
+
+pub struct Directory {
+    path: PathBuf,
+}
+
+impl File for Directory {
+    type InitArgs = ();
+    fn new(path: PathBuf, _args: Self::InitArgs) -> Result<Self> {
+        std::fs::create_dir_all(&path)?;
+        Ok(Directory { path })
+    }
+    fn create_hardlink_to(&self, _path: PathBuf) -> Result<Self> {
+        Err(anyhow!("hard link not allowed for directory"))
+    }
+}
+
+impl Drop for Directory {
+    fn drop(&mut self) {
+        if let Err(e) = std::fs::remove_dir_all(&self.path) {
+            eprintln!("{:?}", e);
+        }
+    }
+}

--- a/judge-control-app/src/custom_file/file_factory.rs
+++ b/judge-control-app/src/custom_file/file_factory.rs
@@ -1,39 +1,27 @@
 use std::path::PathBuf;
 
-use anyhow::{anyhow, Result};
-use uuid::Uuid;
-
-use super::traits::{self, File};
-
-pub struct FileFactory {
+struct FileFactory {
     path: PathBuf,
 }
 
-impl traits::FileFactory for FileFactory {
-    // ベースとなる path を指定
-    fn new(path: PathBuf) -> Result<Self> {
-        if path.is_dir() {
-            Ok(FileFactory { path })
-        } else {
-            Err(anyhow!("path must be an existing dir"))
-        }
+impl super::traits::FileFactory for FileFactory {
+    fn new(path: std::path::PathBuf) -> anyhow::Result<Self> {
+        Ok(Self { path })
     }
-    // path/{uuid} にファイルまたはディレクトリを作成
-    fn create_file<FileType: File>(
+    fn create_file<FileType: super::traits::File>(
         &self,
-        uuid: Uuid,
+        uuid: uuid::Uuid,
         args: FileType::InitArgs,
-    ) -> Result<FileType> {
+    ) -> anyhow::Result<FileType> {
         let path = self.path.join(uuid.to_string());
         FileType::new(path, args)
     }
-    // path/{uuid} に original のハードリンクを作成
-    fn create_hardlink_of<FileType: File>(
+    fn create_symlink_of<FileType: super::traits::FileLink>(
         &self,
-        uuid: Uuid,
+        uuid: uuid::Uuid,
         original: &FileType,
-    ) -> Result<FileType> {
+    ) -> anyhow::Result<FileType> {
         let path = self.path.join(uuid.to_string());
-        original.create_hardlink_to(path)
+        original.create_symlink_to(path)
     }
 }

--- a/judge-control-app/src/custom_file/file_factory.rs
+++ b/judge-control-app/src/custom_file/file_factory.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-struct FileFactory {
+pub struct FileFactory {
     path: PathBuf,
 }
 

--- a/judge-control-app/src/custom_file/file_factory.rs
+++ b/judge-control-app/src/custom_file/file_factory.rs
@@ -1,0 +1,39 @@
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Result};
+use uuid::Uuid;
+
+use super::traits::{self, File};
+
+pub struct FileFactory {
+    path: PathBuf,
+}
+
+impl traits::FileFactory for FileFactory {
+    // ベースとなる path を指定
+    fn new(path: PathBuf) -> Result<Self> {
+        if path.is_dir() {
+            Ok(FileFactory { path })
+        } else {
+            Err(anyhow!("path must be an existing dir"))
+        }
+    }
+    // path/{uuid} にファイルまたはディレクトリを作成
+    fn create_file<FileType: File>(
+        &self,
+        uuid: Uuid,
+        args: FileType::InitArgs,
+    ) -> Result<FileType> {
+        let path = self.path.join(uuid.to_string());
+        FileType::new(path, args)
+    }
+    // path/{uuid} に original のハードリンクを作成
+    fn create_hardlink_of<FileType: File>(
+        &self,
+        uuid: Uuid,
+        original: &FileType,
+    ) -> Result<FileType> {
+        let path = self.path.join(uuid.to_string());
+        original.create_hardlink_to(path)
+    }
+}

--- a/judge-control-app/src/custom_file/text_file.rs
+++ b/judge-control-app/src/custom_file/text_file.rs
@@ -6,7 +6,7 @@ use std::{
 
 use super::traits::{File, FileEntity, FileLink};
 
-struct TextFileEntity {
+pub struct TextFileEntity {
     path: PathBuf,
 }
 
@@ -28,7 +28,7 @@ impl Drop for TextFileEntity {
     }
 }
 
-struct TextFileLink {
+pub struct TextFileLink {
     path: PathBuf,
     entity: Arc<RwLock<TextFileEntity>>,
 }

--- a/judge-control-app/src/custom_file/text_file.rs
+++ b/judge-control-app/src/custom_file/text_file.rs
@@ -1,0 +1,49 @@
+use std::{
+    io::{Read, Write},
+    path::PathBuf,
+};
+
+use anyhow::Result;
+
+use super::traits::File;
+
+pub struct TextFile {
+    path: PathBuf,
+}
+
+impl File for TextFile {
+    type InitArgs = Option<String>;
+    fn new(path: PathBuf, args: Self::InitArgs) -> Result<Self> {
+        std::fs::File::create(&path)?;
+        let res = TextFile { path };
+        if let Some(contents) = args {
+            res.write(contents)?;
+        }
+        Ok(res)
+    }
+    fn create_hardlink_to(&self, path: PathBuf) -> Result<Self> {
+        std::fs::hard_link(&self.path, &path)?;
+        Ok(TextFile { path })
+    }
+}
+impl Drop for TextFile {
+    fn drop(&mut self) {
+        if let Err(e) = std::fs::remove_file(&self.path) {
+            eprintln!("{:?}", e);
+        }
+    }
+}
+
+impl TextFile {
+    fn read(&self) -> Result<String> {
+        let mut file = std::fs::OpenOptions::new().read(true).open(&self.path)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+        Ok(contents)
+    }
+    fn write(&self, contents: String) -> Result<()> {
+        let mut file = std::fs::OpenOptions::new().write(true).open(&self.path)?;
+        file.write_all(contents.as_bytes())?;
+        Ok(())
+    }
+}

--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -1,6 +1,9 @@
 #![allow(drop_bounds)]
 use anyhow::{anyhow, Result};
-use std::path::PathBuf;
+use std::{
+    io::{Read, Write},
+    path::PathBuf,
+};
 use uuid::Uuid;
 
 pub trait File: Sized + Drop {
@@ -34,25 +37,29 @@ pub struct TextFile {
 }
 
 impl File for Directory {
-    type InitArgs = todo!();
-    fn new(path: PathBuf, args: Self::InitArgs) -> Result<Self> {
+    type InitArgs = ();
+    fn new(path: PathBuf, _args: Self::InitArgs) -> Result<Self> {
         std::fs::create_dir_all(&path)?;
         Ok(Directory { path })
     }
-    fn get_hardlink_to(&self, path: PathBuf) -> Result<Self> {
+    fn get_hardlink_to(&self, _path: PathBuf) -> Result<Self> {
         Err(anyhow!("hard link not allowed for directory"))
     }
 }
 
 impl File for TextFile {
-    type InitArgs = todo!();
+    type InitArgs = Option<String>;
     fn new(path: PathBuf, args: Self::InitArgs) -> Result<Self> {
         std::fs::File::create(&path)?;
-        Ok(TextFile { path })
+        let res = TextFile { path };
+        if let Some(contents) = args {
+            res.write(contents)?;
+        }
+        Ok(res)
     }
     fn get_hardlink_to(&self, path: PathBuf) -> Result<Self> {
         std::fs::hard_link(&self.path, &path)?;
-        TextFile::new(path, todo!())
+        TextFile::new(path, None)
     }
 }
 
@@ -70,14 +77,14 @@ impl Drop for TextFile {
 
 impl TextFile {
     fn read(&self) -> Result<String> {
-        let mut f = OpenOptions::new().read(true).open(&self.path)?;
+        let mut file = std::fs::OpenOptions::new().read(true).open(&self.path)?;
         let mut contents = String::new();
-        f.read_to_string(&mut contents)?;
+        file.read_to_string(&mut contents)?;
         Ok(contents)
     }
     fn write(&self, contents: String) -> Result<()> {
-        let mut f = OpenOptions::new().write(true).open(&self.path)?;
-        f.write_all(contents.as_bytes())?;
+        let mut file = std::fs::OpenOptions::new().write(true).open(&self.path)?;
+        file.write_all(contents.as_bytes())?;
         Ok(())
     }
 }

--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -93,6 +93,7 @@ pub struct FileManager {
 }
 
 impl FileFactory for FileManager {
+    // ベースとなる path を指定
     fn new(path: PathBuf) -> Result<Self> {
         if path.is_dir() {
             Ok(FileManager { path })
@@ -100,10 +101,12 @@ impl FileFactory for FileManager {
             Err(anyhow!("path must be an existing dir"))
         }
     }
+    // path/{uuid} にファイルまたはディレクトリを作成
     fn create_file<FileType: File>(&self, uuid: Uuid, args: FileType::InitArgs) -> Result<FileType> {
         let path = self.path.join(uuid.to_string());
         FileType::new(path, args)
     }
+    // path/{uuid} に original のハードリンクを作成
     fn create_hardlink_of<FileType: File>(&self, uuid: Uuid, original: FileType) -> Result<FileType> {
         let path = self.path.join(uuid.to_string());
         original.create_hardlink_to(path)

--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -6,14 +6,19 @@ use uuid::Uuid;
 pub trait File: Sized + Drop {
     type InitArgs;
     fn new(path: PathBuf, args: Self::InitArgs) -> Result<Self>;
-    fn create_hardlink_to(&self, path: PathBuf) -> Result<Self>;
+}
+
+pub trait FileEntity: File {}
+
+pub trait FileLink: File {
+    fn create_symlink_to(&self, path: PathBuf) -> Result<Self>;
 }
 
 pub trait FileFactory: Sized {
     fn new(path: PathBuf) -> Result<Self>;
     fn create_file<FileType: File>(&self, uuid: Uuid, args: FileType::InitArgs)
         -> Result<FileType>;
-    fn create_hardlink_of<FileType: File>(
+    fn create_symlink_of<FileType: FileLink>(
         &self,
         uuid: Uuid,
         original: &FileType,

--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -65,13 +65,17 @@ impl File for TextFile {
 
 impl Drop for Directory {
     fn drop(&mut self) {
-        std::fs::remove_dir_all(&self.path);
+        if let Err(e) = std::fs::remove_dir_all(&self.path) {
+            eprintln!("{:?}", e);
+        }
     }
 }
 
 impl Drop for TextFile {
     fn drop(&mut self) {
-        std::fs::remove_file(&self.path);
+        if let Err(e) = std::fs::remove_file(&self.path) {
+            eprintln!("{:?}", e);
+        }
     }
 }
 

--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -23,11 +23,6 @@ pub trait FileFactory: Sized {
     ) -> Result<FileType>;
 }
 
-pub enum CustomFile {
-    Directory(Directory),
-    TextFile(TextFile),
-}
-
 pub struct Directory {
     path: PathBuf,
 }

--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -1,5 +1,5 @@
 #![allow(drop_bounds)]
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use std::path::PathBuf;
 use uuid::Uuid;
 
@@ -36,40 +36,48 @@ pub struct TextFile {
 impl File for Directory {
     type InitArgs = todo!();
     fn new(path: PathBuf, args: Self::InitArgs) -> Result<Self> {
-        todo!();
+        std::fs::create_dir_all(&path)?;
+        Ok(Directory { path })
     }
     fn get_hardlink_to(&self, path: PathBuf) -> Result<Self> {
-        todo!();
+        Err(anyhow!("hard link not allowed for directory"))
     }
 }
 
 impl File for TextFile {
     type InitArgs = todo!();
     fn new(path: PathBuf, args: Self::InitArgs) -> Result<Self> {
-        todo!();
+        std::fs::File::create(&path)?;
+        Ok(TextFile { path })
     }
     fn get_hardlink_to(&self, path: PathBuf) -> Result<Self> {
-        todo!();
+        std::fs::hard_link(&self.path, &path)?;
+        TextFile::new(path, todo!())
     }
 }
 
 impl Drop for Directory {
     fn drop(&mut self) {
-        todo!();
+        std::fs::remove_dir_all(&self.path);
     }
 }
 
 impl Drop for TextFile {
     fn drop(&mut self) {
-        todo!();
+        std::fs::remove_file(&self.path);
     }
 }
 
 impl TextFile {
-    fn read(&self) -> String {
-        todo!();
+    fn read(&self) -> Result<String> {
+        let mut f = OpenOptions::new().read(true).open(&self.path)?;
+        let mut contents = String::new();
+        f.read_to_string(&mut contents)?;
+        Ok(contents)
     }
-    fn write(&self, contents: String) {
-        todo!();
+    fn write(&self, contents: String) -> Result<()> {
+        let mut f = OpenOptions::new().write(true).open(&self.path)?;
+        f.write_all(contents.as_bytes())?;
+        Ok(())
     }
 }

--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -32,3 +32,44 @@ pub struct Directory {
 pub struct TextFile {
     path: PathBuf,
 }
+
+impl File for Directory {
+    type InitArgs = todo!();
+    fn new(path: PathBuf, args: Self::InitArgs) -> Result<Self> {
+        todo!();
+    }
+    fn get_hardlink_to(&self, path: PathBuf) -> Result<Self> {
+        todo!();
+    }
+}
+
+impl File for TextFile {
+    type InitArgs = todo!();
+    fn new(path: PathBuf, args: Self::InitArgs) -> Result<Self> {
+        todo!();
+    }
+    fn get_hardlink_to(&self, path: PathBuf) -> Result<Self> {
+        todo!();
+    }
+}
+
+impl Drop for Directory {
+    fn drop(&mut self) {
+        todo!();
+    }
+}
+
+impl Drop for TextFile {
+    fn drop(&mut self) {
+        todo!();
+    }
+}
+
+impl TextFile {
+    fn read(&self) -> String {
+        todo!();
+    }
+    fn write(&self, contents: String) {
+        todo!();
+    }
+}

--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -19,7 +19,7 @@ pub trait FileFactory: Sized {
     fn create_hardlink_of<FileType: File>(
         &self,
         uuid: Uuid,
-        original: FileType,
+        original: &FileType,
     ) -> Result<FileType>;
 }
 
@@ -107,7 +107,7 @@ impl FileFactory for FileManager {
         FileType::new(path, args)
     }
     // path/{uuid} に original のハードリンクを作成
-    fn create_hardlink_of<FileType: File>(&self, uuid: Uuid, original: FileType) -> Result<FileType> {
+    fn create_hardlink_of<FileType: File>(&self, uuid: Uuid, original: &FileType) -> Result<FileType> {
         let path = self.path.join(uuid.to_string());
         original.create_hardlink_to(path)
     }

--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -88,3 +88,25 @@ impl TextFile {
         Ok(())
     }
 }
+
+pub struct FileManager {
+    path: PathBuf,
+}
+
+impl FileFactory for FileManager {
+    fn new(path: PathBuf) -> Result<Self> {
+        if path.is_dir() {
+            Ok(FileManager { path })
+        } else {
+            Err(anyhow!("path must be an existing dir"))
+        }
+    }
+    fn get_file<FileType: File>(&self, uuid: Uuid, args: FileType::InitArgs) -> Result<FileType> {
+        let path = self.path.join(uuid.to_string());
+        FileType::new(path, args)
+    }
+    fn get_hardlink_of<FileType: File>(&self, uuid: Uuid, original: FileType) -> Result<FileType> {
+        let path = self.path.join(uuid.to_string());
+        original.get_hardlink_to(path)
+    }
+}

--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -37,7 +37,7 @@ impl File for Directory {
         std::fs::create_dir_all(&path)?;
         Ok(Directory { path })
     }
-    fn get_hardlink_to(&self, _path: PathBuf) -> Result<Self> {
+    fn create_hardlink_to(&self, _path: PathBuf) -> Result<Self> {
         Err(anyhow!("hard link not allowed for directory"))
     }
 }
@@ -52,7 +52,7 @@ impl File for TextFile {
         }
         Ok(res)
     }
-    fn get_hardlink_to(&self, path: PathBuf) -> Result<Self> {
+    fn create_hardlink_to(&self, path: PathBuf) -> Result<Self> {
         std::fs::hard_link(&self.path, &path)?;
         TextFile::new(path, None)
     }
@@ -100,12 +100,12 @@ impl FileFactory for FileManager {
             Err(anyhow!("path must be an existing dir"))
         }
     }
-    fn get_file<FileType: File>(&self, uuid: Uuid, args: FileType::InitArgs) -> Result<FileType> {
+    fn create_file<FileType: File>(&self, uuid: Uuid, args: FileType::InitArgs) -> Result<FileType> {
         let path = self.path.join(uuid.to_string());
         FileType::new(path, args)
     }
-    fn get_hardlink_of<FileType: File>(&self, uuid: Uuid, original: FileType) -> Result<FileType> {
+    fn create_hardlink_of<FileType: File>(&self, uuid: Uuid, original: FileType) -> Result<FileType> {
         let path = self.path.join(uuid.to_string());
-        original.get_hardlink_to(path)
+        original.create_hardlink_to(path)
     }
 }

--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -19,3 +19,16 @@ pub trait FileFactory: Sized {
         original: FileType,
     ) -> Result<FileType>;
 }
+
+pub enum CustomFile {
+    Directory(Directory),
+    TextFile(TextFile),
+}
+
+pub struct Directory {
+    path: PathBuf,
+}
+
+pub struct TextFile {
+    path: PathBuf,
+}

--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -54,7 +54,7 @@ impl File for TextFile {
     }
     fn create_hardlink_to(&self, path: PathBuf) -> Result<Self> {
         std::fs::hard_link(&self.path, &path)?;
-        TextFile::new(path, None)
+        Ok(TextFile { path })
     }
 }
 

--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -1,9 +1,6 @@
 #![allow(drop_bounds)]
-use anyhow::{anyhow, Result};
-use std::{
-    io::{Read, Write},
-    path::PathBuf,
-};
+use anyhow::Result;
+use std::path::PathBuf;
 use uuid::Uuid;
 
 pub trait File: Sized + Drop {
@@ -21,94 +18,4 @@ pub trait FileFactory: Sized {
         uuid: Uuid,
         original: &FileType,
     ) -> Result<FileType>;
-}
-
-pub struct Directory {
-    path: PathBuf,
-}
-
-pub struct TextFile {
-    path: PathBuf,
-}
-
-impl File for Directory {
-    type InitArgs = ();
-    fn new(path: PathBuf, _args: Self::InitArgs) -> Result<Self> {
-        std::fs::create_dir_all(&path)?;
-        Ok(Directory { path })
-    }
-    fn create_hardlink_to(&self, _path: PathBuf) -> Result<Self> {
-        Err(anyhow!("hard link not allowed for directory"))
-    }
-}
-
-impl File for TextFile {
-    type InitArgs = Option<String>;
-    fn new(path: PathBuf, args: Self::InitArgs) -> Result<Self> {
-        std::fs::File::create(&path)?;
-        let res = TextFile { path };
-        if let Some(contents) = args {
-            res.write(contents)?;
-        }
-        Ok(res)
-    }
-    fn create_hardlink_to(&self, path: PathBuf) -> Result<Self> {
-        std::fs::hard_link(&self.path, &path)?;
-        Ok(TextFile { path })
-    }
-}
-
-impl Drop for Directory {
-    fn drop(&mut self) {
-        if let Err(e) = std::fs::remove_dir_all(&self.path) {
-            eprintln!("{:?}", e);
-        }
-    }
-}
-
-impl Drop for TextFile {
-    fn drop(&mut self) {
-        if let Err(e) = std::fs::remove_file(&self.path) {
-            eprintln!("{:?}", e);
-        }
-    }
-}
-
-impl TextFile {
-    fn read(&self) -> Result<String> {
-        let mut file = std::fs::OpenOptions::new().read(true).open(&self.path)?;
-        let mut contents = String::new();
-        file.read_to_string(&mut contents)?;
-        Ok(contents)
-    }
-    fn write(&self, contents: String) -> Result<()> {
-        let mut file = std::fs::OpenOptions::new().write(true).open(&self.path)?;
-        file.write_all(contents.as_bytes())?;
-        Ok(())
-    }
-}
-
-pub struct FileManager {
-    path: PathBuf,
-}
-
-impl FileFactory for FileManager {
-    // ベースとなる path を指定
-    fn new(path: PathBuf) -> Result<Self> {
-        if path.is_dir() {
-            Ok(FileManager { path })
-        } else {
-            Err(anyhow!("path must be an existing dir"))
-        }
-    }
-    // path/{uuid} にファイルまたはディレクトリを作成
-    fn create_file<FileType: File>(&self, uuid: Uuid, args: FileType::InitArgs) -> Result<FileType> {
-        let path = self.path.join(uuid.to_string());
-        FileType::new(path, args)
-    }
-    // path/{uuid} に original のハードリンクを作成
-    fn create_hardlink_of<FileType: File>(&self, uuid: Uuid, original: &FileType) -> Result<FileType> {
-        let path = self.path.join(uuid.to_string());
-        original.create_hardlink_to(path)
-    }
 }


### PR DESCRIPTION
## 関連Issue

- close #7

## 概要

ファイルを管理する構造体を実装しました。下記のような使い方を想定しています。

- `FileFactory::new()` に基準となるパスを渡す。ファイル / ディレクトリ / ハードリンクはこのパス直下に作られる。
- `FileFactory::create_file()` でファイル / ディレクトリを作成する。
- `FileFactory::create_hardlink_of()` でファイルのハードリンクを作成する。
- ファイル / ディレクトリがドロップすると、これは削除される。

```rust
#[cfg(test)]
mod tests {
    use std::{path::PathBuf, thread::sleep, time::Duration};

    use anyhow::Result;
    use uuid::Uuid;

    use crate::custom_file::{
        directory::Directory, file_factory::FileFactory, text_file::TextFile,
        traits::FileFactory as _,
    };

    #[test]
    fn test() -> Result<()> {
        let path = PathBuf::from(".");
        let ff = FileFactory::new(path.clone())?;
        {
            // "./{uuid}" ディレクトリを作成
            let uuid = Uuid::new_v4();
            let dir = ff.create_file::<Directory>(uuid, ())?;

            let path2 = path.join(uuid.to_string());
            let ff2 = FileFactory::new(path2)?;
            {
                // "./{uuid}/{uuid2}" ファイルを作成，"hoge" と書き込み
                let uuid2 = Uuid::new_v4();
                let contents = "hoge".to_string();
                let file = ff2.create_file::<TextFile>(uuid2, Some(contents))?;
                {
                    // "./{uuid}/{uuid3}" に "./{uuid}/{uuid2}" のハードリンクを作成
                    let uuid3 = Uuid::new_v4();
                    let hardlink = ff2.create_hardlink_of::<TextFile>(uuid3, &file)?;
                    sleep(Duration::from_secs(5));
                    // hardlink がドロップ，"./{uuid}/{uuid3}" ファイルを削除
                }
                sleep(Duration::from_secs(5));
                // file がドロップ，"./{uuid}/{uuid2}" ファイルを削除
            }
            sleep(Duration::from_secs(5));
            // dir がドロップ，"./{uuid}" ディレクトリを削除
        }
        Ok(())
    }
}
```

## チェックリスト
- [x] テストが通っている
- [ ] 下記のいずれかを満たしている
    - - [ ] 変更点についてテストを追加/修正した
    - - [ ] テストを追加するissueを立てた
    - - [ ] テストが不要な変更である
- [x] レビュワーを指定した
- [x] タグをつけた

## 補足
- 使用する側は、`use crate::custom_file::traits::FileFactory as _;` をする必要があります（`struct` と `trait` の名前が被っているため）。