### PR TITLE
Feat/#61 remote exec

### DIFF
--- a/judge-control-app/Cargo.toml
+++ b/judge-control-app/Cargo.toml
@@ -17,3 +17,4 @@ uuid = { version = "1.0", features = ["serde", "v4"] }
 reqwest = "0.12.5"
 anyhow = "1.0"
 thiserror = "1.0.63"
+ssh2 = "0.9.4"

--- a/judge-control-app/src/main.rs
+++ b/judge-control-app/src/main.rs
@@ -1,5 +1,5 @@
 mod custom_file;
-mod telnet;
+mod remote_exec;
 mod text_resource_repository;
 
 fn main() {

--- a/judge-control-app/src/remote_exec.rs
+++ b/judge-control-app/src/remote_exec.rs
@@ -1,1 +1,2 @@
+pub mod ssh;
 pub mod traits;

--- a/judge-control-app/src/remote_exec/ssh.rs
+++ b/judge-control-app/src/remote_exec/ssh.rs
@@ -1,0 +1,73 @@
+use super::traits::RemoteExec;
+use anyhow::{Context, Result};
+use ssh2::{Channel, Session};
+use std::io::Read;
+use std::time::Duration;
+use tokio::{
+    net::{TcpStream, ToSocketAddrs},
+    time::timeout,
+};
+
+pub struct SshConnection<AddrType: ToSocketAddrs> {
+    addrs: AddrType,
+    username: String,
+    password: String,
+}
+
+impl<AddrType: ToSocketAddrs> RemoteExec<AddrType> for SshConnection<AddrType> {
+    async fn exec(
+        &mut self,
+        cmd: &str,
+        connection_time_limit: Duration,
+        execution_time_limit: Duration,
+    ) -> Result<String> {
+        let connect_future = async move {
+            // SSH接続の確立
+            let channel = self
+                .connect()
+                .await?;
+            // 時間制限付きでコマンドを実行
+            let exec_with_timeout_future = timeout(
+                execution_time_limit,
+                self.exec_inner(cmd, channel)).await?;
+            let result = exec_with_timeout_future.context("Execution time limit exceeded")?;
+            Ok(result)
+        };
+        // 接続時間制限付きでSSH接続
+        let connect_with_timeout_future = timeout(
+            connection_time_limit,
+            connect_future
+        );
+        let result = connect_with_timeout_future
+            .await
+            .context("Connection time limit exceeded")?;
+        result
+    }
+}
+
+impl<AddrType: ToSocketAddrs> SshConnection<AddrType> {
+    // SSH接続の確立
+    async fn connect(&self) -> Result<Channel> {
+        let tcp = TcpStream::connect(&self.addrs)
+            .await
+            .context("Failed to connect to the SSH server")?;
+        let mut sess = Session::new().context("Failed to create a new SSH session")?;
+        sess.set_tcp_stream(tcp);
+        sess.handshake()
+            .context("Failed to perform SSH handshake")?;
+        sess.userauth_password(&self.username, &self.password)
+            .context("Failed to authenticate with the SSH server")?;
+        let chan = sess
+            .channel_session()
+            .context("Failed to open a new channel for SSH")?;
+        Ok(chan)
+    }
+
+    // コマンドの実行
+    async fn exec_inner(&self, cmd: &str, mut chan: Channel) -> Result<String> {
+        chan.exec(cmd).context("Failed to execute the command via SSH")?;
+        let mut output = String::new();
+        chan.read_to_string(&mut output).context("Failed to read the output from SSH")?;
+        Ok(output)
+    }
+}

--- a/judge-control-app/src/remote_exec/ssh.rs
+++ b/judge-control-app/src/remote_exec/ssh.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 use super::traits::RemoteExec;
 use anyhow::{Context, Result};
 use ssh2::{Channel, Session};
@@ -9,9 +12,9 @@ use tokio::{
 };
 
 pub struct SshConnection<AddrType: ToSocketAddrs> {
-    addrs: AddrType,
-    username: String,
-    password: String,
+    pub addrs: AddrType,
+    pub username: String,
+    pub password: String,
 }
 
 impl<AddrType: ToSocketAddrs> RemoteExec<AddrType> for SshConnection<AddrType> {
@@ -65,116 +68,5 @@ impl<AddrType: ToSocketAddrs> SshConnection<AddrType> {
         chan.read_to_string(&mut output)
             .context("Failed to read the output from SSH")?;
         Ok(output)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::time::Duration;
-    use uuid::Uuid;
-
-    #[tokio::test]
-    async fn test_ssh_connection() {
-        let uuid = Uuid::new_v4();
-        if !check_docker_installed().await {
-            return;
-        }
-        if !check_docker_running().await {
-            if check_su_privilege().await {
-                start_docker_daemon().await.unwrap();
-            } else {
-                eprintln!("Neither docker is running nor you have su privilege");
-                return;
-            }
-        }
-        build_ssh_docker_image(uuid).await.unwrap();
-        let result = run_ssh_docker_container(uuid).await;
-        remove_docker_image(uuid).await.unwrap();
-        assert!(result.is_ok());
-        let mut ssh = SshConnection {
-            addrs: "localhost:2022",
-            username: "root".to_string(),
-            password: "password".to_string(),
-        };
-        let resp = ssh
-            .exec(
-                "cat /flag",
-                Duration::from_secs(60),
-                Duration::from_secs(60),
-            )
-            .await;
-        stop_ssh_docker_container(uuid).await.unwrap();
-        assert!(resp.is_ok());
-        assert_eq!(resp.unwrap(), "TEST_FLAG\n");
-    }
-
-    async fn check_docker_installed() -> bool {
-        let output = std::process::Command::new("docker")
-            .arg("--version")
-            .output()
-            .unwrap();
-        output.status.success()
-    }
-
-    async fn start_docker_daemon() -> Result<()> {
-        let _ = std::process::Command::new("systemctl")
-            .args(&["start", "docker"])
-            .output()?;
-        Ok(())
-    }
-
-    async fn check_docker_running() -> bool {
-        let output = std::process::Command::new("systemctl")
-            .args(&["is-active", "docker"])
-            .output()
-            .unwrap();
-        output.status.success()
-    }
-
-    async fn check_su_privilege() -> bool {
-        let output = std::process::Command::new("su")
-            .arg("-c")
-            .arg("whoami")
-            .output()
-            .unwrap();
-        output.status.success()
-    }
-
-    async fn build_ssh_docker_image(uuid: Uuid) -> Result<()> {
-        let _ = std::process::Command::new("docker")
-            .args(&["build", "-t", &format!("ssh-server-test-{}", uuid), "."])
-            .current_dir("tests/ssh_server")
-            .output()?;
-        Ok(())
-    }
-
-    async fn remove_docker_image(uuid: Uuid) -> Result<()> {
-        let _ = std::process::Command::new("docker")
-            .args(&["rmi", &format!("ssh-server-test-{}", uuid)])
-            .output()?;
-        Ok(())
-    }
-
-    async fn run_ssh_docker_container(uuid: Uuid) -> Result<()> {
-        let _ = std::process::Command::new("docker")
-            .args(&[
-                "run",
-                "-d",
-                "-p",
-                "2022:2022",
-                "--name",
-                &format!("ssh-server-test-{}", uuid),
-                &format!("ssh-server-test-{}", uuid),
-            ])
-            .output()?;
-        Ok(())
-    }
-
-    async fn stop_ssh_docker_container(uuid: Uuid) -> Result<()> {
-        let _ = std::process::Command::new("docker")
-            .args(&["stop", &format!("ssh-server-test-{}", uuid)])
-            .output()?;
-        Ok(())
     }
 }

--- a/judge-control-app/src/remote_exec/ssh.rs
+++ b/judge-control-app/src/remote_exec/ssh.rs
@@ -80,7 +80,7 @@ mod tests {
         if !check_docker_installed().await {
             return;
         }
-        //start_docker_daemon().await.unwrap();
+        start_docker_daemon().await.unwrap();
         build_ssh_docker_image(uuid).await.unwrap();
         let result = run_ssh_docker_container(uuid).await;
         remove_docker_image(uuid).await.unwrap();
@@ -116,7 +116,7 @@ mod tests {
 
     async fn build_ssh_docker_image(uuid: Uuid) -> Result<()> {
         let _ = std::process::Command::new("docker")
-            .args(&["build", "-t", &format!("ssh-server-test-{}", uuid), "-"])
+            .args(&["build", "-t", &format!("ssh-server-test-{}", uuid), "."])
             .current_dir("tests/ssh_server")
             .output()?;
         Ok(())
@@ -133,8 +133,9 @@ mod tests {
         let _ = std::process::Command::new("docker")
             .args(&[
                 "run",
-                "--rm",
                 "-d",
+                "-p",
+                "2022:2022",
                 "--name",
                 &format!("ssh-server-test-{}", uuid),
                 &format!("ssh-server-test-{}", uuid),

--- a/judge-control-app/src/remote_exec/ssh.rs
+++ b/judge-control-app/src/remote_exec/ssh.rs
@@ -127,7 +127,8 @@ mod tests {
     async fn check_docker_running() -> bool {
         let output = std::process::Command::new("systemctl")
             .args(&["is-active", "docker"])
-            .output().unwrap();
+            .output()
+            .unwrap();
         output.status.success()
     }
 

--- a/judge-control-app/src/remote_exec/ssh.rs
+++ b/judge-control-app/src/remote_exec/ssh.rs
@@ -10,6 +10,7 @@ use tokio::{
     net::{TcpStream, ToSocketAddrs},
     time::timeout,
 };
+use thiserror::Error as ThisError;
 
 pub struct SshConnection<AddrType: ToSocketAddrs> {
     pub addrs: AddrType,
@@ -17,56 +18,104 @@ pub struct SshConnection<AddrType: ToSocketAddrs> {
     pub password: String,
 }
 
-impl<AddrType: ToSocketAddrs> RemoteExec<AddrType> for SshConnection<AddrType> {
+#[derive(ThisError, Debug)]
+pub enum SshExecError {
+    #[error("Execution in remote SSH server failed")]
+    RemoteExecutionFailed(#[from] RemoteServerError),
+    #[error("Internal error while SSH execution")]
+    InternalServerError(#[from] InternalServerError),
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error(transparent)]
+pub struct RemoteServerError(anyhow::Error);
+
+#[derive(thiserror::Error, Debug)]
+#[error(transparent)]
+pub struct InternalServerError(anyhow::Error);
+
+impl<AddrType: ToSocketAddrs> RemoteExec<AddrType, SshExecError> for SshConnection<AddrType> {
     async fn exec(
         &mut self,
         cmd: &str,
         connection_time_limit: Duration,
         execution_time_limit: Duration,
-    ) -> Result<String> {
-        let connect_future = async move {
-            // SSH接続の確立
-            let channel = self.connect().await?;
-            // 時間制限付きでコマンドを実行
-            let exec_with_timeout_future =
-                timeout(execution_time_limit, self.exec_inner(cmd, channel)).await?;
-            let result = exec_with_timeout_future.context("Execution time limit exceeded")?;
-            Ok(result)
-        };
-        // 接続時間制限付きでSSH接続
-        let connect_with_timeout_future = timeout(connection_time_limit, connect_future);
-        let result = connect_with_timeout_future
+    ) -> Result<String, SshExecError> {
+        let channel = self
+            .connect_with_timeout(connection_time_limit)
             .await
-            .context("Connection time limit exceeded")?;
-        result
+            .map_err(|e| SshExecError::InternalServerError(e))?;
+        let output = self
+            .exec_inner_with_timeout(cmd, channel, execution_time_limit)
+            .await
+            .map_err(|e| SshExecError::RemoteExecutionFailed(e))?;
+        Ok(output)
     }
 }
 
 impl<AddrType: ToSocketAddrs> SshConnection<AddrType> {
     // SSH接続の確立
-    async fn connect(&self) -> Result<Channel> {
-        let tcp = TcpStream::connect(&self.addrs)
+    async fn connect_with_timeout(&self, connection_time_limit: Duration) -> Result<Channel, InternalServerError> {
+        let connect_future = async move {
+
+            let tcp = TcpStream::connect(&self.addrs)
+                .await
+                .context("Failed to connect to the SSH server")?;
+            let mut sess = Session::new().context("Failed to create a new SSH session")?;
+            sess.set_tcp_stream(tcp);
+            sess.handshake()
+                .context("Failed to perform SSH handshake")?;
+            sess.userauth_password(&self.username, &self.password)
+                .context("Failed to authenticate with the SSH server")?;
+            let chan = sess
+                .channel_session()
+                .context("Failed to open a new channel for SSH")?;
+            Ok(chan)
+        };
+        let timeout_future = async move {
+            let result = timeout(
+                connection_time_limit,
+                connect_future
+            )
+                .await
+                .map_err(|e| anyhow::Error::from(e))
+                .context("Connection time limit exceeded")?;
+            result
+        };
+        let result: Result<Channel, InternalServerError> = timeout_future
             .await
-            .context("Failed to connect to the SSH server")?;
-        let mut sess = Session::new().context("Failed to create a new SSH session")?;
-        sess.set_tcp_stream(tcp);
-        sess.handshake()
-            .context("Failed to perform SSH handshake")?;
-        sess.userauth_password(&self.username, &self.password)
-            .context("Failed to authenticate with the SSH server")?;
-        let chan = sess
-            .channel_session()
-            .context("Failed to open a new channel for SSH")?;
-        Ok(chan)
+            .map_err(|e| InternalServerError(e).into());
+        result
     }
 
     // コマンドの実行
-    async fn exec_inner(&self, cmd: &str, mut chan: Channel) -> Result<String> {
-        chan.exec(cmd)
-            .context("Failed to execute the command via SSH")?;
-        let mut output = String::new();
-        chan.read_to_string(&mut output)
-            .context("Failed to read the output from SSH")?;
-        Ok(output)
+    async fn exec_inner_with_timeout(
+        &self,
+        cmd: &str,
+        mut chan: Channel,
+        execution_time_limit: Duration,
+    ) -> Result<String, RemoteServerError> {
+        let exec_future = async move {
+            chan.exec(cmd)
+                .context("Failed to execute the command via SSH")?;
+            let mut output = String::new();
+            chan.read_to_string(&mut output)
+                .context("Failed to read the output from SSH")?;
+            Ok(output)
+        };
+        let timeout_future = async move {
+            let result = timeout(
+                execution_time_limit,
+                exec_future
+            )
+                .await
+                .map_err(|e| anyhow::Error::from(e))
+                .context("Execution time limit exceeded")?;
+            result
+        };
+        let result: Result<String, RemoteServerError> = timeout_future
+            .await
+            .map_err(|e| RemoteServerError(e).into());
+        result
     }
 }

--- a/judge-control-app/src/remote_exec/ssh.rs
+++ b/judge-control-app/src/remote_exec/ssh.rs
@@ -172,7 +172,7 @@ mod tests {
     }
 
     async fn stop_ssh_docker_container(uuid: Uuid) -> Result<()> {
-        let output = std::process::Command::new("docker")
+        let _ = std::process::Command::new("docker")
             .args(&["stop", &format!("ssh-server-test-{}", uuid)])
             .output()?;
         Ok(())

--- a/judge-control-app/src/remote_exec/ssh.rs
+++ b/judge-control-app/src/remote_exec/ssh.rs
@@ -80,7 +80,7 @@ mod tests {
         if !check_docker_installed().await {
             return;
         }
-        start_docker_daemon().await.unwrap();
+        //start_docker_daemon().await.unwrap();
         build_ssh_docker_image(uuid).await.unwrap();
         let result = run_ssh_docker_container(uuid).await;
         remove_docker_image(uuid).await.unwrap();

--- a/judge-control-app/src/remote_exec/ssh.rs
+++ b/judge-control-app/src/remote_exec/ssh.rs
@@ -103,7 +103,10 @@ mod tests {
     }
 
     async fn check_docker_installed() -> bool {
-        let output = std::process::Command::new("docker").arg("--version").output().unwrap();
+        let output = std::process::Command::new("docker")
+            .arg("--version")
+            .output()
+            .unwrap();
         output.status.success()
     }
 

--- a/judge-control-app/src/remote_exec/ssh.rs
+++ b/judge-control-app/src/remote_exec/ssh.rs
@@ -75,15 +75,13 @@ impl<AddrType: ToSocketAddrs> SshConnection<AddrType> {
             Ok(chan)
         };
         let timeout_future = async move {
-            
             timeout(connection_time_limit, connect_future)
                 .await
                 .map_err(anyhow::Error::from)
                 .context("Connection time limit exceeded")?
         };
-        let result: Result<Channel, InternalServerError> = timeout_future
-            .await
-            .map_err(InternalServerError);
+        let result: Result<Channel, InternalServerError> =
+            timeout_future.await.map_err(InternalServerError);
         result
     }
 
@@ -114,9 +112,8 @@ impl<AddrType: ToSocketAddrs> SshConnection<AddrType> {
             }
             result
         };
-        let result: Result<String, RemoteServerError> = timeout_future
-            .await
-            .map_err(RemoteServerError);
+        let result: Result<String, RemoteServerError> =
+            timeout_future.await.map_err(RemoteServerError);
         result
     }
 }

--- a/judge-control-app/src/remote_exec/ssh.rs
+++ b/judge-control-app/src/remote_exec/ssh.rs
@@ -80,7 +80,7 @@ mod tests {
         if !check_docker_installed().await {
             return;
         }
-        start_docker_daemon().await.unwrap();
+        //start_docker_daemon().await.unwrap();
         build_ssh_docker_image(uuid).await.unwrap();
         let result = run_ssh_docker_container(uuid).await;
         remove_docker_image(uuid).await.unwrap();
@@ -108,7 +108,9 @@ mod tests {
     }
 
     async fn start_docker_daemon() -> Result<()> {
-        let _ = std::process::Command::new("dockerd").output()?;
+        let _ = std::process::Command::new("systemctl")
+            .args(&["start", "docker"])
+            .output()?;
         Ok(())
     }
 

--- a/judge-control-app/src/remote_exec/ssh.rs
+++ b/judge-control-app/src/remote_exec/ssh.rs
@@ -21,7 +21,7 @@ pub struct SshConnection<AddrType: ToSocketAddrs> {
 #[derive(ThisError, Debug)]
 pub enum SshExecError {
     #[error("Execution in remote SSH server failed")]
-    RemoteExecutionFailed(#[from] RemoteServerError),
+    RemoteServerError(#[from] RemoteServerError),
     #[error("Internal error while SSH execution")]
     InternalServerError(#[from] InternalServerError),
 }
@@ -48,7 +48,7 @@ impl<AddrType: ToSocketAddrs> RemoteExec<AddrType, SshExecError> for SshConnecti
         let output = self
             .exec_inner_with_timeout(cmd, channel, execution_time_limit)
             .await
-            .map_err(|e| SshExecError::RemoteExecutionFailed(e))?;
+            .map_err(|e| SshExecError::RemoteServerError(e))?;
         Ok(output)
     }
 }

--- a/judge-control-app/src/remote_exec/ssh/tests.rs
+++ b/judge-control-app/src/remote_exec/ssh/tests.rs
@@ -1,5 +1,4 @@
-#[allow(clippy::unwrap_used)]
-
+#![allow(clippy::unwrap_used)]
 use super::super::{ssh::SshConnection, traits::RemoteExec};
 use anyhow::Result;
 use std::time::Duration;

--- a/judge-control-app/src/remote_exec/ssh/tests.rs
+++ b/judge-control-app/src/remote_exec/ssh/tests.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::unwrap_used)]
 
 use super::super::{ssh::SshConnection, traits::RemoteExec};
 use anyhow::Result;

--- a/judge-control-app/src/remote_exec/ssh/tests.rs
+++ b/judge-control-app/src/remote_exec/ssh/tests.rs
@@ -1,0 +1,109 @@
+
+use super::super::{ssh::SshConnection, traits::RemoteExec};
+use anyhow::Result;
+use std::time::Duration;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn test_ssh_connection() {
+    let uuid = Uuid::new_v4();
+    if !check_docker_installed().await {
+        return;
+    }
+    if !check_docker_running().await {
+        if check_su_privilege().await {
+            start_docker_daemon().await.unwrap();
+        } else {
+            eprintln!("Neither docker is running nor you have su privilege");
+            return;
+        }
+    }
+    build_ssh_docker_image(uuid).await.unwrap();
+    let result = run_ssh_docker_container(uuid).await;
+    remove_docker_image(uuid).await.unwrap();
+    assert!(result.is_ok());
+    let mut ssh = SshConnection {
+        addrs: "localhost:2022",
+        username: "root".to_string(),
+        password: "password".to_string(),
+    };
+    let resp = ssh
+        .exec(
+            "cat /flag",
+            Duration::from_secs(60),
+            Duration::from_secs(60),
+        )
+        .await;
+    stop_ssh_docker_container(uuid).await.unwrap();
+    assert!(resp.is_ok());
+    assert_eq!(resp.unwrap(), "TEST_FLAG\n");
+}
+
+async fn check_docker_installed() -> bool {
+    let output = std::process::Command::new("docker")
+        .arg("--version")
+        .output()
+        .unwrap();
+    output.status.success()
+}
+
+async fn start_docker_daemon() -> Result<()> {
+    let _ = std::process::Command::new("systemctl")
+        .args(&["start", "docker"])
+        .output()?;
+    Ok(())
+}
+
+async fn check_docker_running() -> bool {
+    let output = std::process::Command::new("systemctl")
+        .args(&["is-active", "docker"])
+        .output()
+        .unwrap();
+    output.status.success()
+}
+
+async fn check_su_privilege() -> bool {
+    let output = std::process::Command::new("su")
+        .arg("-c")
+        .arg("whoami")
+        .output()
+        .unwrap();
+    output.status.success()
+}
+
+async fn build_ssh_docker_image(uuid: Uuid) -> Result<()> {
+    let _ = std::process::Command::new("docker")
+        .args(&["build", "-t", &format!("ssh-server-test-{}", uuid), "."])
+        .current_dir("tests/ssh_server")
+        .output()?;
+    Ok(())
+}
+
+async fn remove_docker_image(uuid: Uuid) -> Result<()> {
+    let _ = std::process::Command::new("docker")
+        .args(&["rmi", &format!("ssh-server-test-{}", uuid)])
+        .output()?;
+    Ok(())
+}
+
+async fn run_ssh_docker_container(uuid: Uuid) -> Result<()> {
+    let _ = std::process::Command::new("docker")
+        .args(&[
+            "run",
+            "-d",
+            "-p",
+            "2022:2022",
+            "--name",
+            &format!("ssh-server-test-{}", uuid),
+            &format!("ssh-server-test-{}", uuid),
+        ])
+        .output()?;
+    Ok(())
+}
+
+async fn stop_ssh_docker_container(uuid: Uuid) -> Result<()> {
+    let _ = std::process::Command::new("docker")
+        .args(&["stop", &format!("ssh-server-test-{}", uuid)])
+        .output()?;
+    Ok(())
+}

--- a/judge-control-app/src/remote_exec/ssh/tests.rs
+++ b/judge-control-app/src/remote_exec/ssh/tests.rs
@@ -35,7 +35,11 @@ async fn test_ssh_connection_timeout() {
         password: "password".to_string(),
     };
     let resp = ssh
-        .exec("sleep 1", Duration::from_millis(1), Duration::from_millis(1))
+        .exec(
+            "sleep 1",
+            Duration::from_millis(1),
+            Duration::from_millis(1),
+        )
         .await;
     stop_ssh_docker_container(uuid).await.unwrap();
     assert!(resp.is_err_and(|e| match e {

--- a/judge-control-app/src/remote_exec/ssh/tests.rs
+++ b/judge-control-app/src/remote_exec/ssh/tests.rs
@@ -49,7 +49,7 @@ async fn test_ssh_connection_timeout() {
     return;
 }
 
-async fn activate_container(uuid: Uuid) -> () {
+async fn activate_container(uuid: Uuid) {
     if !check_docker_installed().await {
         return;
     }
@@ -77,14 +77,14 @@ async fn check_docker_installed() -> bool {
 
 async fn start_docker_daemon() -> Result<()> {
     let _ = std::process::Command::new("systemctl")
-        .args(&["start", "docker"])
+        .args(["start", "docker"])
         .output()?;
     Ok(())
 }
 
 async fn check_docker_running() -> bool {
     let output = std::process::Command::new("systemctl")
-        .args(&["is-active", "docker"])
+        .args(["is-active", "docker"])
         .output()
         .unwrap();
     output.status.success()
@@ -101,7 +101,7 @@ async fn check_su_privilege() -> bool {
 
 async fn build_ssh_docker_image(uuid: Uuid) -> Result<()> {
     let _ = std::process::Command::new("docker")
-        .args(&["build", "-t", &format!("ssh-server-test-{}", uuid), "."])
+        .args(["build", "-t", &format!("ssh-server-test-{}", uuid), "."])
         .current_dir("tests/ssh_server")
         .output()?;
     Ok(())
@@ -109,14 +109,14 @@ async fn build_ssh_docker_image(uuid: Uuid) -> Result<()> {
 
 async fn remove_docker_image(uuid: Uuid) -> Result<()> {
     let _ = std::process::Command::new("docker")
-        .args(&["rmi", &format!("ssh-server-test-{}", uuid)])
+        .args(["rmi", &format!("ssh-server-test-{}", uuid)])
         .output()?;
     Ok(())
 }
 
 async fn run_ssh_docker_container(uuid: Uuid) -> Result<()> {
     let _ = std::process::Command::new("docker")
-        .args(&[
+        .args([
             "run",
             "-d",
             "-p",
@@ -131,7 +131,7 @@ async fn run_ssh_docker_container(uuid: Uuid) -> Result<()> {
 
 async fn stop_ssh_docker_container(uuid: Uuid) -> Result<()> {
     let _ = std::process::Command::new("docker")
-        .args(&["stop", &format!("ssh-server-test-{}", uuid)])
+        .args(["stop", &format!("ssh-server-test-{}", uuid)])
         .output()?;
     Ok(())
 }

--- a/judge-control-app/src/remote_exec/traits.rs
+++ b/judge-control-app/src/remote_exec/traits.rs
@@ -1,6 +1,6 @@
+use std::error::Error;
 use std::time::Duration;
 use tokio::net::ToSocketAddrs;
-use std::error::Error;
 
 pub trait RemoteExec<AddrType: ToSocketAddrs, ErrorType: Error> {
     async fn exec(

--- a/judge-control-app/src/remote_exec/traits.rs
+++ b/judge-control-app/src/remote_exec/traits.rs
@@ -1,0 +1,12 @@
+use anyhow::Result;
+use std::time::Duration;
+use tokio::net::ToSocketAddrs;
+
+pub trait RemoteExec<AddrType: ToSocketAddrs> {
+    async fn exec(
+        &mut self,
+        cmd: &str,
+        connection_time_limit: Duration,
+        execution_time_limit: Duration,
+    ) -> Result<String>;
+}

--- a/judge-control-app/src/remote_exec/traits.rs
+++ b/judge-control-app/src/remote_exec/traits.rs
@@ -1,12 +1,12 @@
-use anyhow::Result;
 use std::time::Duration;
 use tokio::net::ToSocketAddrs;
+use std::error::Error;
 
-pub trait RemoteExec<AddrType: ToSocketAddrs> {
+pub trait RemoteExec<AddrType: ToSocketAddrs, ErrorType: Error> {
     async fn exec(
         &mut self,
         cmd: &str,
         connection_time_limit: Duration,
         execution_time_limit: Duration,
-    ) -> Result<String>;
+    ) -> Result<String, ErrorType>;
 }

--- a/judge-control-app/src/telnet/traits.rs
+++ b/judge-control-app/src/telnet/traits.rs
@@ -1,8 +1,0 @@
-use anyhow::Result;
-use std::future::Future;
-use std::net::ToSocketAddrs;
-
-pub trait Telnet {
-    fn new<Addr: ToSocketAddrs>(addr: Addr) -> Self;
-    fn exec(&mut self, cmd: &str) -> impl Future<Output = Result<String>>;
-}

--- a/judge-control-app/tests/ssh_server/Dockerfile
+++ b/judge-control-app/tests/ssh_server/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:latest
+
+# 必要なパッケージをインストール
+RUN apt-get update && apt-get install -y \
+    openssh-server
+
+# SSH用のディレクトリを作成
+RUN mkdir /var/run/sshd
+
+# rootユーザーのパスワードを設定
+RUN echo 'root:password' | chpasswd
+
+# rootでのSSHアクセスを許可、パスワード認証を有効に
+RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config
+
+# SSHデーモンのリッスンポートを2022に変更
+RUN sed -i 's/#Port 22/Port 2022/' /etc/ssh/sshd_config
+
+# テスト用のフラッグを設定
+RUN echo 'TEST_FLAG' > /flag
+
+# 2022番ポートを開放
+EXPOSE 2022
+
+# SSHサービスを起動
+CMD ["/usr/sbin/sshd", "-D"]


### PR DESCRIPTION
## 関連Issue

- close #61

## 概要

telnetからsshに変更し実装

## 変更内容

- tenlet moduleを削除
- remote_exec moduleを作成
- RemoteExec traitを実装
- RemoteExecの実装としてSshConnectionを実装

## チェックリスト
- [x] テストが通っている
- [x] 下記のいずれかを満たしている
    - - [x] 変更点についてテストを追加/修正した
    - - [ ] テストを追加するissueを立てた
    - - [ ] テストが不要な変更である
- [x] レビュワーを指定した
- [x] タグをつけた

## 補足