### PR TITLE
#7 と #60 の実装について意見を伺いたい

### DIFF
--- a/judge-control-app/src/custom_file.rs
+++ b/judge-control-app/src/custom_file.rs
@@ -1,3 +1,4 @@
 pub mod traits;
 
+pub mod directory;
 pub mod text_file;

--- a/judge-control-app/src/custom_file.rs
+++ b/judge-control-app/src/custom_file.rs
@@ -1,1 +1,3 @@
 pub mod traits;
+
+pub mod text_file;

--- a/judge-control-app/src/custom_file.rs
+++ b/judge-control-app/src/custom_file.rs
@@ -1,4 +1,5 @@
 pub mod traits;
 
 pub mod directory;
+pub mod file_factory;
 pub mod text_file;

--- a/judge-control-app/src/custom_file/directory.rs
+++ b/judge-control-app/src/custom_file/directory.rs
@@ -13,7 +13,7 @@ impl FileEntity for DirectoryEntity {}
 
 impl File for DirectoryEntity {
     type InitArgs = ();
-    fn new(path: PathBuf, args: Self::InitArgs) -> anyhow::Result<Self> {
+    fn new(path: PathBuf, _args: Self::InitArgs) -> anyhow::Result<Self> {
         std::fs::create_dir_all(&path)?;
         Ok(Self { path })
     }
@@ -21,7 +21,8 @@ impl File for DirectoryEntity {
 
 impl Drop for DirectoryEntity {
     fn drop(&mut self) {
-        std::fs::remove_dir_all(&self.path);
+        let _ = std::fs::remove_dir_all(&self.path);
+        unimplemented!("error handling for file deletion failure");
     }
 }
 
@@ -49,6 +50,7 @@ impl File for DirectoryLink {
 
 impl Drop for DirectoryLink {
     fn drop(&mut self) {
-        std::fs::remove_dir_all(&self.path);
+        let _ = std::fs::remove_dir_all(&self.path);
+        unimplemented!("error handling for file deletion failure");
     }
 }

--- a/judge-control-app/src/custom_file/directory.rs
+++ b/judge-control-app/src/custom_file/directory.rs
@@ -1,0 +1,54 @@
+use std::{
+    path::PathBuf,
+    sync::{Arc, RwLock},
+};
+
+use super::traits::{File, FileEntity, FileLink};
+
+struct DirectoryEntity {
+    path: PathBuf,
+}
+
+impl FileEntity for DirectoryEntity {}
+
+impl File for DirectoryEntity {
+    type InitArgs = ();
+    fn new(path: PathBuf, args: Self::InitArgs) -> anyhow::Result<Self> {
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for DirectoryEntity {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.path);
+    }
+}
+
+struct DirectoryLink {
+    path: PathBuf,
+    entity: Arc<RwLock<DirectoryEntity>>,
+}
+
+impl FileLink for DirectoryLink {
+    fn create_symlink_to(&self, path: PathBuf) -> anyhow::Result<Self> {
+        Self::new(path, self.entity.clone())
+    }
+}
+
+impl File for DirectoryLink {
+    type InitArgs = Arc<RwLock<DirectoryEntity>>;
+    fn new(path: PathBuf, args: Self::InitArgs) -> anyhow::Result<Self> {
+        std::os::unix::fs::symlink(&args.read().unwrap().path, &path)?;
+        Ok(Self {
+            path,
+            entity: args.clone(),
+        })
+    }
+}
+
+impl Drop for DirectoryLink {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.path);
+    }
+}

--- a/judge-control-app/src/custom_file/file_factory.rs
+++ b/judge-control-app/src/custom_file/file_factory.rs
@@ -1,0 +1,27 @@
+use std::path::PathBuf;
+
+struct FileFactory {
+    path: PathBuf,
+}
+
+impl super::traits::FileFactory for FileFactory {
+    fn new(path: std::path::PathBuf) -> anyhow::Result<Self> {
+        Ok(Self { path })
+    }
+    fn create_file<FileType: super::traits::File>(
+        &self,
+        uuid: uuid::Uuid,
+        args: FileType::InitArgs,
+    ) -> anyhow::Result<FileType> {
+        let path = self.path.join(uuid.to_string());
+        FileType::new(path, args)
+    }
+    fn create_symlink_of<FileType: super::traits::FileLink>(
+        &self,
+        uuid: uuid::Uuid,
+        original: &FileType,
+    ) -> anyhow::Result<FileType> {
+        let path = self.path.join(uuid.to_string());
+        original.create_symlink_to(path)
+    }
+}

--- a/judge-control-app/src/custom_file/text_file.rs
+++ b/judge-control-app/src/custom_file/text_file.rs
@@ -1,0 +1,77 @@
+#[cfg(test)]
+mod tests;
+
+use std::{
+    io::Write,
+    path::PathBuf,
+    sync::{Arc, RwLock},
+};
+
+use super::traits::File;
+
+struct FileAccess;
+
+struct TextFileInner {
+    path: PathBuf,
+    _parent: Option<TextFile>,
+    lock: Arc<RwLock<FileAccess>>,
+}
+
+impl Drop for TextFileInner {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+        // ./text_file/tests.rs でのテスト用
+        eprintln!("{:?}", self.path);
+    }
+}
+
+// TextFileInner を Arc でラップして使う．
+//
+// シンボリックリンク自体を子，リンク先を親と表現するとき，子は Arc<親> を持つ．
+// （これにより子から drop することが保証されるはず？）
+//
+// オリジナルファイルには Arc<RwLock<FileAccess>> を新たに作成して持たせる．
+// シンボリックリンク（子や孫すべて）にはその clone を持たせる．
+// （元ファイルを根とする根付き木全体で 1 つの RwLock<FileAccess> を共有しているはず？）
+#[derive(Clone)]
+struct TextFile(Arc<TextFileInner>);
+
+impl File for TextFile {
+    type InitArgs = String;
+    fn new(path: PathBuf, args: Self::InitArgs) -> anyhow::Result<Self> {
+        // ファイルの作成・初期化
+        let mut file = std::fs::File::create(&path)?;
+        file.write_all(args.as_bytes())?;
+
+        // オリジナルファイルなので，親は存在しない．
+        // Arc<RwLock<FileAccess>> を新たに作成して持たせる．
+        let inner = TextFileInner {
+            path,
+            _parent: None,
+            lock: Arc::new(RwLock::new(FileAccess)),
+        };
+
+        Ok(TextFile(Arc::new(inner)))
+    }
+    fn create_symlink_to(&self, path: PathBuf) -> anyhow::Result<Self> {
+        // シンボリックリンクの作成
+        std::os::unix::fs::symlink(&self.0.path, &path)?;
+
+        // 自身の clone を子に持たせる．
+        // Arc<RwLock<FileAccess>> の clone を持たせる．
+        let inner = TextFileInner {
+            path,
+            _parent: Some(self.clone()),
+            lock: self.0.lock.clone(),
+        };
+
+        Ok(TextFile(Arc::new(inner)))
+    }
+}
+
+impl Drop for TextFile {
+    fn drop(&mut self) {
+        // Arc<TextFileInner> が drop したときに呼び出すと，複数回呼び出されてしまう．
+        // TextFileInner が drop したときに呼び出されるようにしたい．
+    }
+}

--- a/judge-control-app/src/custom_file/text_file.rs
+++ b/judge-control-app/src/custom_file/text_file.rs
@@ -7,11 +7,13 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use super::traits::File;
+use super::traits::{File, FileEntity, FileLink};
 
 struct TextFileEntity {
     path: PathBuf,
 }
+
+impl FileEntity for TextFileEntity {}
 
 impl File for TextFileEntity {
     type InitArgs = String;
@@ -19,9 +21,6 @@ impl File for TextFileEntity {
         let mut file = std::fs::File::create(&path)?;
         file.write_all(args.as_bytes())?;
         Ok(Self { path })
-    }
-    fn create_symlink_to(&self, path: PathBuf) -> anyhow::Result<Self> {
-        unimplemented!();
     }
 }
 
@@ -37,6 +36,12 @@ struct TextFileLink {
     entity: Arc<RwLock<TextFileEntity>>,
 }
 
+impl FileLink for TextFileLink {
+    fn create_symlink_to(&self, path: PathBuf) -> anyhow::Result<Self> {
+        Self::new(path, self.entity.clone())
+    }
+}
+
 impl File for TextFileLink {
     type InitArgs = Arc<RwLock<TextFileEntity>>;
     fn new(path: PathBuf, args: Self::InitArgs) -> anyhow::Result<Self> {
@@ -45,9 +50,6 @@ impl File for TextFileLink {
             path,
             entity: args.clone(),
         })
-    }
-    fn create_symlink_to(&self, path: PathBuf) -> anyhow::Result<Self> {
-        Self::new(path, self.entity.clone())
     }
 }
 

--- a/judge-control-app/src/custom_file/text_file.rs
+++ b/judge-control-app/src/custom_file/text_file.rs
@@ -9,69 +9,51 @@ use std::{
 
 use super::traits::File;
 
-struct FileAccess;
-
-struct TextFileInner {
+struct TextFileEntity {
     path: PathBuf,
-    _parent: Option<TextFile>,
-    lock: Arc<RwLock<FileAccess>>,
 }
 
-impl Drop for TextFileInner {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.path);
-        // ./text_file/tests.rs でのテスト用
-        eprintln!("{:?}", self.path);
-    }
-}
-
-// TextFileInner を Arc でラップして使う．
-//
-// シンボリックリンク自体を子，リンク先を親と表現するとき，子は Arc<親> を持つ．
-// （これにより子から drop することが保証されるはず？）
-//
-// オリジナルファイルには Arc<RwLock<FileAccess>> を新たに作成して持たせる．
-// シンボリックリンク（子や孫すべて）にはその clone を持たせる．
-// （元ファイルを根とする根付き木全体で 1 つの RwLock<FileAccess> を共有しているはず？）
-#[derive(Clone)]
-struct TextFile(Arc<TextFileInner>);
-
-impl File for TextFile {
+impl File for TextFileEntity {
     type InitArgs = String;
     fn new(path: PathBuf, args: Self::InitArgs) -> anyhow::Result<Self> {
-        // ファイルの作成・初期化
         let mut file = std::fs::File::create(&path)?;
         file.write_all(args.as_bytes())?;
-
-        // オリジナルファイルなので，親は存在しない．
-        // Arc<RwLock<FileAccess>> を新たに作成して持たせる．
-        let inner = TextFileInner {
-            path,
-            _parent: None,
-            lock: Arc::new(RwLock::new(FileAccess)),
-        };
-
-        Ok(TextFile(Arc::new(inner)))
+        Ok(Self { path })
     }
     fn create_symlink_to(&self, path: PathBuf) -> anyhow::Result<Self> {
-        // シンボリックリンクの作成
-        std::os::unix::fs::symlink(&self.0.path, &path)?;
-
-        // 自身の clone を子に持たせる．
-        // Arc<RwLock<FileAccess>> の clone を持たせる．
-        let inner = TextFileInner {
-            path,
-            _parent: Some(self.clone()),
-            lock: self.0.lock.clone(),
-        };
-
-        Ok(TextFile(Arc::new(inner)))
+        unimplemented!();
     }
 }
 
-impl Drop for TextFile {
+impl Drop for TextFileEntity {
     fn drop(&mut self) {
-        // Arc<TextFileInner> が drop したときに呼び出すと，複数回呼び出されてしまう．
-        // TextFileInner が drop したときに呼び出されるようにしたい．
+        std::fs::remove_file(&self.path);
+        eprintln!("Entity {:?} dropped.", self.path);
+    }
+}
+
+struct TextFileLink {
+    path: PathBuf,
+    entity: Arc<RwLock<TextFileEntity>>,
+}
+
+impl File for TextFileLink {
+    type InitArgs = Arc<RwLock<TextFileEntity>>;
+    fn new(path: PathBuf, args: Self::InitArgs) -> anyhow::Result<Self> {
+        std::os::unix::fs::symlink(&args.read().unwrap().path, &path)?;
+        Ok(Self {
+            path,
+            entity: args.clone(),
+        })
+    }
+    fn create_symlink_to(&self, path: PathBuf) -> anyhow::Result<Self> {
+        Self::new(path, self.entity.clone())
+    }
+}
+
+impl Drop for TextFileLink {
+    fn drop(&mut self) {
+        std::fs::remove_file(&self.path);
+        eprintln!("Link {:?} dropped.", self.path);
     }
 }

--- a/judge-control-app/src/custom_file/text_file.rs
+++ b/judge-control-app/src/custom_file/text_file.rs
@@ -26,8 +26,8 @@ impl File for TextFileEntity {
 
 impl Drop for TextFileEntity {
     fn drop(&mut self) {
-        std::fs::remove_file(&self.path);
-        eprintln!("Entity {:?} dropped.", self.path);
+        let _ = std::fs::remove_file(&self.path);
+        unimplemented!("error handling for file deletion failure");
     }
 }
 
@@ -55,7 +55,7 @@ impl File for TextFileLink {
 
 impl Drop for TextFileLink {
     fn drop(&mut self) {
-        std::fs::remove_file(&self.path);
-        eprintln!("Link {:?} dropped.", self.path);
+        let _ = std::fs::remove_file(&self.path);
+        unimplemented!("error handling for file deletion failure");
     }
 }

--- a/judge-control-app/src/custom_file/text_file/tests.rs
+++ b/judge-control-app/src/custom_file/text_file/tests.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::custom_file::{
     text_file::{TextFileEntity, TextFileLink},
-    traits::File,
+    traits::{File, FileLink},
 };
 
 #[test]

--- a/judge-control-app/src/custom_file/text_file/tests.rs
+++ b/judge-control-app/src/custom_file/text_file/tests.rs
@@ -1,0 +1,29 @@
+use std::path::PathBuf;
+
+use crate::custom_file::traits::File;
+
+use super::TextFile;
+
+#[test]
+fn drop_from_leaves() -> anyhow::Result<()> {
+    let v = {
+        let a = TextFile::new(PathBuf::from("a.txt"), "hello!".to_string())?;
+
+        let b1 = a.create_symlink_to(PathBuf::from("b1.txt"))?;
+        let b2 = a.create_symlink_to(PathBuf::from("b2.txt"))?;
+        let b3 = a.create_symlink_to(PathBuf::from("b3.txt"))?;
+
+        let c1 = b1.create_symlink_to(PathBuf::from("c1.txt"))?;
+        let c2 = b1.create_symlink_to(PathBuf::from("c2.txt"))?;
+        let c3 = b1.create_symlink_to(PathBuf::from("c3.txt"))?;
+
+        vec![a, b1, b2, b3, c1, c2, c3];
+    };
+
+    // たとえば
+    // "b2.txt"→ "b3.txt"→ "c1.txt"→ "c2.txt"→ "c3.txt"→ "b1.txt"→ "a.txt"
+    // のように，葉から drop することが確認できる．
+    drop(v);
+
+    Ok(())
+}

--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -6,14 +6,14 @@ use uuid::Uuid;
 pub trait File: Sized + Drop {
     type InitArgs;
     fn new(path: PathBuf, args: Self::InitArgs) -> Result<Self>;
-    fn create_hardlink_to(&self, path: PathBuf) -> Result<Self>;
+    fn create_symlink_to(&self, path: PathBuf) -> Result<Self>;
 }
 
 pub trait FileFactory: Sized {
     fn new(path: PathBuf) -> Result<Self>;
     fn create_file<FileType: File>(&self, uuid: Uuid, args: FileType::InitArgs)
         -> Result<FileType>;
-    fn create_hardlink_of<FileType: File>(
+    fn create_symlink_of<FileType: File>(
         &self,
         uuid: Uuid,
         original: &FileType,

--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -6,6 +6,11 @@ use uuid::Uuid;
 pub trait File: Sized + Drop {
     type InitArgs;
     fn new(path: PathBuf, args: Self::InitArgs) -> Result<Self>;
+}
+
+pub trait FileEntity: File {}
+
+pub trait FileLink: File {
     fn create_symlink_to(&self, path: PathBuf) -> Result<Self>;
 }
 

--- a/judge-control-app/src/custom_file/traits.rs
+++ b/judge-control-app/src/custom_file/traits.rs
@@ -18,7 +18,7 @@ pub trait FileFactory: Sized {
     fn new(path: PathBuf) -> Result<Self>;
     fn create_file<FileType: File>(&self, uuid: Uuid, args: FileType::InitArgs)
         -> Result<FileType>;
-    fn create_symlink_of<FileType: File>(
+    fn create_symlink_of<FileType: FileLink>(
         &self,
         uuid: Uuid,
         original: &FileType,


### PR DESCRIPTION
## 関連Issue

- related #7
- related #60 

## 概要

意見を伺いたいです．

#7 と #60 を実現するため，以下のように `text_file.rs` の実装をしました．

ファイルの依存関係を，オリジナルファイルを根，シンボリックリンクのリンク先を親，リンク元を子とした根付き木として考えたときに，

- 葉から drop する構造を実現するため，
    - 子に Arc<親> を持たせた．
    - これを実現するため，`TextFileInner` と，これを `Arc` でラップした `TextFile` の 2 つの構造体を用意した．
    - `tests.rs` を書いて正しく動作していそうなことを確認した．
- 根付き木全体で 1 つの `RwLock<FileAccess>` を共有するため，
    - オリジナルファイルに `Arc<RwLock<FileAccess>>` を作成して持たせ，子孫にこれの clone を持たせた．

しかし，以下の状況に直面しました．

- `create_symlink_to` と `drop` とでどちらの構造体に実装したいかが異なる．
    - `create_symlink_to` は `self.clone()` を子に持たせるために `Arc` でラップされた `TextFile` 側に実装したい．
    - `drop` は 1 ファイルに 1 回だけ呼び出されるように `Arc` でラップされていない `TextFileInner` 側に実装したい．

トレイトを書き換えれば解決することではありますが，

- これよりもっと素直な実装はないか
- そもそもこれが正しく動作しそうか（`Arc` 周りの理解が浅くあまり自身がないです）

など意見を伺いたいです．よろしくお願いします．