### PR TITLE
🐛 onetime text is readonly

### DIFF
--- a/src/submission_logic/file_preparation.rs
+++ b/src/submission_logic/file_preparation.rs
@@ -43,22 +43,18 @@ pub async fn prepare_files<
             Ok((name, file))
         })
         .collect::<Result<HashMap<_, _>>>()?;
-    let one_time_text_files = futures::future::join_all(
-        onetime_text_files
-            .into_iter()
-            .enumerate()
-            .map(|(i, writable_file)| {
-                async move {
-                    let name = format!("ONETIME_TEXT_{}", i).to_string();
-                    let readonly = writable_file
-                        .with_context(|| format!("Failed to create onetime text file {}", i))?
-                        .to_readonly()
-                        .await
-                        .with_context(|| format!("Failed to convert onetime text file {}", i))?;
-                    Ok((name, readonly))
-                }
-            }),
-    )
+    let one_time_text_files =
+        futures::future::join_all(onetime_text_files.into_iter().enumerate().map(
+            |(i, writable_file)| async move {
+                let name = format!("ONETIME_TEXT_{}", i).to_string();
+                let readonly = writable_file
+                    .with_context(|| format!("Failed to create onetime text file {}", i))?
+                    .to_readonly()
+                    .await
+                    .with_context(|| format!("Failed to convert onetime text file {}", i))?;
+                Ok((name, readonly))
+            },
+        ))
         .await
         .into_iter()
         .collect::<Result<HashMap<_, _>>>()?;


### PR DESCRIPTION
## 関連Issue

- close #82

## 概要

一度writableの状態でリリースしてしまうとreadonlyに戻せないため

## 変更内容

- onetime textがreadonlyで渡されるように変更

## チェックリスト
- [ ] テストが通っている
- [ ] 下記のいずれかを満たしている
    - - [ ] 変更点についてテストを追加/修正した
    - - [ ] テストを追加するissueを立てた
    - - [ ] テストが不要な変更である
- [ ] レビュワーを指定した
- [ ] タグをつけた

## 補足