### PR TITLE
Feat/#159 define messages between actors

### DIFF
--- a/lib/jobapi/Cargo.toml
+++ b/lib/jobapi/Cargo.toml
@@ -13,3 +13,5 @@ thiserror = {workspace = true}
 futures = {workspace = true}
 chrono = {workspace = true}
 judge_core ={ path = "../judge_core" }
+
+actix = "0.13.5"

--- a/lib/jobapi/src/actor.rs
+++ b/lib/jobapi/src/actor.rs
@@ -1,0 +1,21 @@
+#![allow(unused)]
+use actix::prelude::*;
+use judge_core::*;
+
+pub mod handler;
+pub mod message;
+
+pub struct InstanceSupervisor;
+impl Actor for InstanceSupervisor {
+    type Context = Context<Self>;
+}
+
+pub struct Instance;
+impl Actor for Instance {
+    type Context = Context<Self>;
+}
+
+pub struct FileFactory;
+impl Actor for FileFactory {
+    type Context = Context<Self>;
+}

--- a/lib/jobapi/src/actor/handler.rs
+++ b/lib/jobapi/src/actor/handler.rs
@@ -22,7 +22,7 @@ impl Handler<Execution> for InstanceSupervisor {
 }
 
 impl Handler<Dependency> for Instance {
-    type Result = Result<std::process::Output, job::ExecutionError>;
+    type Result = Result<(OutcomeToken, std::process::Output), job::ExecutionError>;
     fn handle(&mut self, msg: Dependency, ctx: &mut Self::Context) -> Self::Result {
         todo!()
     }

--- a/lib/jobapi/src/actor/handler.rs
+++ b/lib/jobapi/src/actor/handler.rs
@@ -1,0 +1,36 @@
+#![allow(unused)]
+use actix::prelude::*;
+use judge_core::*;
+
+use crate::{
+    actor::{message::*, FileFactory, Instance, InstanceSupervisor},
+    jobapi::{OutcomeToken, ReservationToken},
+};
+
+impl Handler<Reservation> for InstanceSupervisor {
+    type Result = Result<Vec<ReservationToken>, job::ReservationError>;
+    fn handle(&mut self, msg: Reservation, ctx: &mut Self::Context) -> Self::Result {
+        todo!()
+    }
+}
+
+impl Handler<Execution> for InstanceSupervisor {
+    type Result = Result<(OutcomeToken, std::process::Output), job::ExecutionError>;
+    fn handle(&mut self, msg: Execution, ctx: &mut Self::Context) -> Self::Result {
+        todo!()
+    }
+}
+
+impl Handler<Dependency> for Instance {
+    type Result = Result<std::process::Output, job::ExecutionError>;
+    fn handle(&mut self, msg: Dependency, ctx: &mut Self::Context) -> Self::Result {
+        todo!()
+    }
+}
+
+impl Handler<FilePlacement> for FileFactory {
+    type Result = Result<OutcomeToken, job::FilePlacementError>;
+    fn handle(&mut self, msg: FilePlacement, ctx: &mut Self::Context) -> Self::Result {
+        todo!()
+    }
+}

--- a/lib/jobapi/src/actor/message.rs
+++ b/lib/jobapi/src/actor/message.rs
@@ -1,0 +1,30 @@
+#![allow(unused)]
+use actix::prelude::*;
+use judge_core::*;
+
+use crate::jobapi::{OutcomeToken, ReservationToken};
+
+#[derive(Message)]
+#[rtype("Result<Vec<ReservationToken>, job::ReservationError>")]
+pub struct Reservation {
+    count: usize,
+}
+
+#[derive(Message)]
+#[rtype("Result<(OutcomeToken, std::process::Output), job::ExecutionError>")]
+pub struct Execution {
+    reservation: ReservationToken,
+    dependencies: Vec<job::Dependency<OutcomeToken>>,
+}
+
+#[derive(Message)]
+#[rtype("Result<std::process::Output, job::ExecutionError>")]
+pub struct Dependency {
+    dependencies: Vec<job::Dependency<OutcomeToken>>,
+}
+
+#[derive(Message)]
+#[rtype("Result<OutcomeToken, job::FilePlacementError>")]
+pub struct FilePlacement {
+    file_conf: job::FileConf,
+}

--- a/lib/jobapi/src/actor/message.rs
+++ b/lib/jobapi/src/actor/message.rs
@@ -18,7 +18,7 @@ pub struct Execution {
 }
 
 #[derive(Message)]
-#[rtype("Result<std::process::Output, job::ExecutionError>")]
+#[rtype("Result<(OutcomeToken, std::process::Output), job::ExecutionError>")]
 pub struct Dependency {
     dependencies: Vec<job::Dependency<OutcomeToken>>,
 }

--- a/lib/jobapi/src/lib.rs
+++ b/lib/jobapi/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod actor;
 pub mod jobapi;


### PR DESCRIPTION
close #159 

Actor の定義と，Actor 間でやり取りする Message の定義をしました．

## 変更したこと

- 以下の Actor を定義しました．
    - `InstanceSupervisor`
    - `Instance`
    - `FileFactory`
- 以下の Message を定義しました．
    - `Reservation` (`InstanceSupervisor` が処理)
    - `Execution` (`InstanceSupervisor` が処理)
    - `Dependency` (`Instance` が処理)
    - `FilePlacement` (`FileFactory` が処理)
- 各用語は以下の画像に対応します．

![v0](https://github.com/user-attachments/assets/3f3b62f0-83b3-4b81-aaf6-869b59a933aa)