### PR TITLE
reduce necessary envvar

### DIFF
--- a/lib/jobapi/src/aws.rs
+++ b/lib/jobapi/src/aws.rs
@@ -38,8 +38,6 @@ impl AwsClientType {
     pub async fn new() -> Self {
         // check env
         for key in [
-            "AWS_ACCESS_KEY_ID",
-            "AWS_SECRET_ACCESS_KEY",
             "SECURITY_GROUP_ID",
         ] {
             if env::var(key).is_err() {


### PR DESCRIPTION
## 関連Issue

- close  #303

## 概要

AWS周りの認証はInstance Roleで行うことにするので、認証用の環境変数が設定されていなくても問題ない