### PR TITLE
👷 delete build check from backend integration test

### DIFF
--- a/.github/workflows/backend-with-external.yml
+++ b/.github/workflows/backend-with-external.yml
@@ -46,7 +46,5 @@ jobs:
                      -v /tmp/config:/root/.minio \
                      minio/minio server /data
 
-    - name: Build test
-      run: cargo build -p backend_app --release --verbose
     - name: Run test
       run: export CODEGEN_SKIP=true && source app/backend_app/.env.dev && cargo test -- --ignored backend


### PR DESCRIPTION
## 関連Issue

- close #378

## 概要
_rust-build-check.ymlでbackendのビルドをするようにしたため、integration testから削除したい