### PR TITLE
Actor 周りの `unwrap` を消す

### DIFF
--- a/lib/jobapi/src/actor/file_factory.rs
+++ b/lib/jobapi/src/actor/file_factory.rs
@@ -51,7 +51,7 @@ impl FileFactory {
                 respond_to,
             } => {
                 let result = self.handle_file_placement(file_conf).await;
-                respond_to.send(result).unwrap();
+                let _ = respond_to.send(result); // if this send fails, so does the recv.await after
                 Running::Continue
             }
         }

--- a/lib/jobapi/src/actor/instance.rs
+++ b/lib/jobapi/src/actor/instance.rs
@@ -62,12 +62,12 @@ impl Instance {
                     .grpc_client
                     .execute(outcome_id_for_res, dependencies)
                     .await;
-                respond_to.send(result).unwrap();
+                let _ = respond_to.send(result); // if this send fails, so does the recv.await after
                 Running::Continue
             }
             InstanceMessage::Terminate { respond_to } => {
                 let result = self.aws_client.terminate_instance(self.instance_id).await;
-                respond_to.send(result).unwrap();
+                let _ = respond_to.send(result); // if this send fails, so does the recv.await after
                 Running::Stop
             }
         }

--- a/lib/jobapi/src/actor/instance_pool.rs
+++ b/lib/jobapi/src/actor/instance_pool.rs
@@ -54,7 +54,7 @@ impl InstancePool {
         match msg {
             InstancePoolMessage::Reservation { count, respond_to } => {
                 let result = self.handle_reservation(count).await;
-                respond_to.send(result).unwrap();
+                let _ = respond_to.send(result); // if this send fails, so does the recv.await after
                 Running::Continue
             }
             InstancePoolMessage::Execution {
@@ -66,7 +66,7 @@ impl InstancePool {
                 let result = self
                     .handle_execution(reservation, outcome_id_for_res, dependencies)
                     .await;
-                respond_to.send(result).unwrap();
+                let _ = respond_to.send(result); // if this send fails, so does the recv.await after
                 Running::Continue
             }
         }


### PR DESCRIPTION
close #402

## 概要

- send 時のエラーを recv 時のエラーとしてハンドルできる構造になっていたので，send 時の `unwrap` を消した
- エラーメッセージを改めた
