### PR TITLE
fix: add CONTENT_TYPE to allowed headers in CORS configuration

### DIFF
--- a/app/backend_app/src/lib.rs
+++ b/app/backend_app/src/lib.rs
@@ -32,6 +32,7 @@ pub async fn run() -> anyhow::Result<()> {
             http::Method::DELETE,
             http::Method::PUT,
         ])
+        .allow_headers([http::header::CONTENT_TYPE])
         .allow_credentials(true);
 
     let app = handler::make_router(di_container)


### PR DESCRIPTION
## 関連Issue

- close #458 

## 概要
content-tpyeの設定忘れでした(申し訳ない)