### PR TITLE
validate source code length to prevent exceeding SQL text type limit

### DIFF
--- a/lib/backend_usecase/src/service/submission.rs
+++ b/lib/backend_usecase/src/service/submission.rs
@@ -266,7 +266,6 @@ impl<
         problem_id: String,
         body: CreateSubmissionData,
     ) -> anyhow::Result<SubmissionDto, UsecaseError> {
-        
         // dbのtext型の最大値に合わせる
         if body.source.len() > 65_535 {
             return Err(UsecaseError::ValidateError);


### PR DESCRIPTION
## 概要
source code へのvalidateを忘れていた